### PR TITLE
Fix deprecated encodeSync

### DIFF
--- a/lib/plantuml-encoder.js
+++ b/lib/plantuml-encoder.js
@@ -15,5 +15,5 @@ module.exports.encode = function (text) {
 
 // Deprecated, might be removed in future releases
 module.exports.encodeSync = function (text) {
-  module.exports.encode(text)
+  return module.exports.encode(text)
 }


### PR DESCRIPTION
encodeSync didn't return the expected value.
This is used in https://github.com/markushedvall/node-plantuml/blob/master/lib/node-plantuml.js#L42 and breaks that repo's encode functionality.
