### PR TITLE
chore: mismatch version in console

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "plantuml-encoder",
   "main": "dist/plantuml-encoder.js",
-  "version": "1.2.4",
   "homepage": "https://github.com/markushedvall/plantuml-encoder",
   "authors": [
     "Markus Hedvall <mackanhedvall@gmail.com>"


### PR DESCRIPTION
version number in bower.json is deprecated. https://github.com/bower/spec/blob/master/json.md
It'll look into tags in git instead.
and no more mismatch version console output while bower install